### PR TITLE
Bus stop routes overview: colours distinguishing up/downroute

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "busrouter-sg",
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fix #47 

- Add `.prettierrc` so I don't overwrite / format all the existing files 😅
- Implement different color for up/down-route

Currently the implementation is quite crude:
- For ⇄ and → route, check direction and assign color accordingly to different direction
- For ⟲ route, split the coordinates array into 2 `[0, length / 2 + 1]` `[length / 2, length]` so the looping route is dissected into 2 _almost_ equally long segments
   - This definitely ignores the stop where the loop happens because the stop may not necessarily be the exact halfway of the looping route
   - It can certainly be improved, but will be more effort intensive and I think better to prove that this color differentiation can be done first before improving it and also that this feature is given the green light
- Current implementation is also only applicable to single route display. Not yet implemented for route preview, multiple routes display, hover over route, etc.

This feature will also remove color gradient for route colouring due to Mapbox's `line-gradient` not able to accept data-driven property